### PR TITLE
130 feature configurable tracking error metrics

### DIFF
--- a/hdsemg_pipe/actions/tracking_error_metrics.py
+++ b/hdsemg_pipe/actions/tracking_error_metrics.py
@@ -1,0 +1,198 @@
+"""
+Tracking Error Metrics
+
+Computes quality scores (0–100, higher = better) from required vs. performed
+path signals. Each metric normalises its raw error into the same 0–100 scale
+so the existing colour-mapping logic in FileQualitySelectionWizardWidget works
+unchanged when the user switches metric.
+
+Default tier thresholds (score boundaries for Excellent / Good / OK / Troubled)
+are stored in ``DEFAULT_THRESHOLDS`` keyed by metric name.  These are also the
+factory-reset values used by ``TrackingErrorThresholdsDialog``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Metric names (used as keys everywhere)
+# ---------------------------------------------------------------------------
+
+METRIC_NRMSE = "NRMSE"
+METRIC_RMSE = "RMSE"
+METRIC_MSE = "MSE"
+METRIC_MAE = "MAE"
+METRIC_PEARSON_R = "Pearson r"
+
+METRIC_NAMES = [METRIC_NRMSE, METRIC_RMSE, METRIC_MSE, METRIC_MAE, METRIC_PEARSON_R]
+
+# Human-readable labels shown in the combo box
+METRIC_LABELS: Dict[str, str] = {
+    METRIC_NRMSE: "NRMSE",
+    METRIC_RMSE: "RMSE",
+    METRIC_MSE: "MSE",
+    METRIC_MAE: "MAE",
+    METRIC_PEARSON_R: "Pearson r",
+}
+
+# ---------------------------------------------------------------------------
+# Default tier thresholds  (score >= value → tier)
+# Order: excellent, good, ok, troubled  (anything below troubled → bad)
+# ---------------------------------------------------------------------------
+
+DEFAULT_THRESHOLDS: Dict[str, Dict[str, float]] = {
+    METRIC_NRMSE: {
+        "excellent": 90.0,
+        "good": 80.0,
+        "ok": 70.0,
+        "troubled": 60.0,
+    },
+    METRIC_RMSE: {
+        "excellent": 90.0,
+        "good": 80.0,
+        "ok": 70.0,
+        "troubled": 60.0,
+    },
+    METRIC_MSE: {
+        "excellent": 90.0,
+        "good": 80.0,
+        "ok": 70.0,
+        "troubled": 60.0,
+    },
+    METRIC_MAE: {
+        "excellent": 90.0,
+        "good": 80.0,
+        "ok": 70.0,
+        "troubled": 60.0,
+    },
+    METRIC_PEARSON_R: {
+        "excellent": 90.0,
+        "good": 80.0,
+        "ok": 70.0,
+        "troubled": 60.0,
+    },
+}
+
+# Tier display labels and order (descending)
+TIER_ORDER = ["excellent", "good", "ok", "troubled"]
+TIER_DISPLAY: Dict[str, str] = {
+    "excellent": "Excellent",
+    "good": "Good",
+    "ok": "OK",
+    "troubled": "Troubled",
+}
+
+
+# ---------------------------------------------------------------------------
+# Individual metric implementations (return 0–100 quality score)
+# ---------------------------------------------------------------------------
+
+def _nrmse_score(required: np.ndarray, performed: np.ndarray) -> Optional[float]:
+    """score = max(0, (1 − RMSE / range(required)) × 100)."""
+    req_range = required.max() - required.min()
+    if req_range < 1e-10:
+        return None
+    rmse = float(np.sqrt(np.mean((required - performed) ** 2)))
+    return max(0.0, (1.0 - rmse / req_range) * 100.0)
+
+
+def _rmse_score(required: np.ndarray, performed: np.ndarray) -> Optional[float]:
+    """score = max(0, (1 − RMSE / std(required)) × 100).
+
+    Normalises by std instead of range so it is robust to extreme spikes.
+    """
+    std = float(np.std(required))
+    if std < 1e-10:
+        return None
+    rmse = float(np.sqrt(np.mean((required - performed) ** 2)))
+    return max(0.0, (1.0 - rmse / std) * 100.0)
+
+
+def _mse_score(required: np.ndarray, performed: np.ndarray) -> Optional[float]:
+    """score = max(0, (1 − MSE / var(required)) × 100).
+
+    Equivalent to 100 × (1 − normalised MSE).
+    """
+    var = float(np.var(required))
+    if var < 1e-10:
+        return None
+    mse = float(np.mean((required - performed) ** 2))
+    return max(0.0, (1.0 - mse / var) * 100.0)
+
+
+def _mae_score(required: np.ndarray, performed: np.ndarray) -> Optional[float]:
+    """score = max(0, (1 − MAE / (0.5 × range(required))) × 100).
+
+    Normalises MAE by half the signal range to give a comparable scale.
+    """
+    req_range = required.max() - required.min()
+    if req_range < 1e-10:
+        return None
+    mae = float(np.mean(np.abs(required - performed)))
+    return max(0.0, (1.0 - mae / (req_range * 0.5)) * 100.0)
+
+
+def _pearson_r_score(required: np.ndarray, performed: np.ndarray) -> Optional[float]:
+    """score = max(0, r) × 100  where r is the Pearson correlation coefficient."""
+    req_std = float(np.std(required))
+    perf_std = float(np.std(performed))
+    if req_std < 1e-10 or perf_std < 1e-10:
+        return None
+    r = float(np.corrcoef(required, performed)[0, 1])
+    if np.isnan(r):
+        return None
+    return max(0.0, r) * 100.0
+
+
+# ---------------------------------------------------------------------------
+# Public dispatcher
+# ---------------------------------------------------------------------------
+
+_DISPATCH = {
+    METRIC_NRMSE: _nrmse_score,
+    METRIC_RMSE: _rmse_score,
+    METRIC_MSE: _mse_score,
+    METRIC_MAE: _mae_score,
+    METRIC_PEARSON_R: _pearson_r_score,
+}
+
+
+def compute_metric(
+    metric_name: str,
+    required: np.ndarray,
+    performed: np.ndarray,
+) -> Optional[float]:
+    """Return a 0–100 quality score for the given metric.
+
+    Parameters
+    ----------
+    metric_name:
+        One of the ``METRIC_*`` constants (e.g. ``METRIC_NRMSE``).
+    required:
+        1-D array of the required / target path signal.
+    performed:
+        1-D array of the performed path signal.  Trimmed to ``len(required)``
+        if longer; padded with the last value if shorter.
+
+    Returns
+    -------
+    float or None
+        Score in [0, 100] where 100 is a perfect match, or ``None`` if the
+        score cannot be computed (e.g. constant required signal).
+    """
+    fn = _DISPATCH.get(metric_name)
+    if fn is None:
+        raise ValueError(
+            f"Unknown metric '{metric_name}'. "
+            f"Valid choices: {list(_DISPATCH.keys())}"
+        )
+
+    min_len = min(len(required), len(performed))
+    req = np.asarray(required[:min_len], dtype=float)
+    perf = np.asarray(performed[:min_len], dtype=float)
+
+    return fn(req, perf)

--- a/hdsemg_pipe/config/config_enums.py
+++ b/hdsemg_pipe/config/config_enums.py
@@ -12,6 +12,8 @@ class Settings(Enum):
     OCTAVE_INSTALLED = "OCTAVE_INSTALLED"  # Octave + oct2py available
     MUEDIT_PATH = "MUEDIT_PATH"  # Path to MUEdit folder (to add to MATLAB path)
     MUEDIT_LAUNCH_METHOD = "MUEDIT_LAUNCH_METHOD"  # Method to launch MUEdit
+    TRACKING_ERROR_METRIC = "TRACKING_ERROR_METRIC"  # Selected metric name, e.g. "NRMSE"
+    TRACKING_ERROR_THRESHOLDS = "TRACKING_ERROR_THRESHOLDS"  # Dict[metric → Dict[tier → float]]
 
 
 class LineNoiseRegion(Enum):

--- a/hdsemg_pipe/widgets/dialogs/TrackingErrorThresholdsDialog.py
+++ b/hdsemg_pipe/widgets/dialogs/TrackingErrorThresholdsDialog.py
@@ -1,0 +1,217 @@
+"""
+Tracking Error Thresholds Dialog
+
+Lets the user view and edit the quality tier boundaries (excellent / good / ok /
+troubled) for the currently selected tracking-error metric.  Changes are saved
+immediately to ``config`` so the parent widget can repaint live.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel,
+    QPushButton, QDoubleSpinBox, QFrame, QWidget,
+)
+
+from hdsemg_pipe.actions.tracking_error_metrics import (
+    DEFAULT_THRESHOLDS, TIER_ORDER, TIER_DISPLAY,
+)
+from hdsemg_pipe.config.config_enums import Settings
+from hdsemg_pipe.config.config_manager import config
+from hdsemg_pipe.ui_elements.theme import (
+    BorderRadius, Colors, Fonts, Spacing, Styles,
+)
+
+
+class TrackingErrorThresholdsDialog(QDialog):
+    """Modal dialog for editing quality tier thresholds for a given metric.
+
+    The dialog reads the current thresholds from ``config`` (falling back to
+    ``DEFAULT_THRESHOLDS`` when none are stored), shows four ``QDoubleSpinBox``
+    rows (excellent / good / ok / troubled), and writes changes back to
+    ``config`` on "Save".  A "Reset to defaults" button restores per-metric
+    factory values without closing the dialog.
+
+    Usage::
+
+        dlg = TrackingErrorThresholdsDialog("NRMSE", parent=self)
+        dlg.exec_()
+        # config already updated – caller can repaint immediately
+    """
+
+    def __init__(self, metric_name: str, parent=None):
+        super().__init__(parent)
+        self._metric_name = metric_name
+        self.setWindowTitle(f"Quality Thresholds — {metric_name}")
+        self.setModal(True)
+        self.setMinimumWidth(400)
+        self.setStyleSheet(f"QDialog {{ background-color: {Colors.BG_PRIMARY}; }}")
+        self._spinboxes: Dict[str, QDoubleSpinBox] = {}
+        self._build_ui()
+        self._load_current_thresholds()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(Spacing.XL, Spacing.XL, Spacing.XL, Spacing.XL)
+        root.setSpacing(Spacing.LG)
+
+        # Header
+        header = QLabel(
+            f"Set score boundaries for <b>{self._metric_name}</b>.<br>"
+            "<small style='color:gray;'>Files with a score ≥ Excellent threshold are "
+            "rated Excellent; ≥ Good → Good; etc.</small>"
+        )
+        header.setTextFormat(Qt.RichText)
+        header.setWordWrap(True)
+        header.setStyleSheet(
+            f"QLabel {{ color: {Colors.TEXT_PRIMARY}; font-size: {Fonts.SIZE_SM}; }}"
+        )
+        root.addWidget(header)
+
+        sep = QFrame()
+        sep.setFrameShape(QFrame.HLine)
+        sep.setStyleSheet(f"color: {Colors.BORDER_MUTED};")
+        root.addWidget(sep)
+
+        # Tier rows
+        tier_colors = {
+            "excellent": Colors.GREEN_500,
+            "good": Colors.BLUE_500,
+            "ok": Colors.YELLOW_500,
+            "troubled": Colors.ORANGE_500,
+        }
+        form = QWidget()
+        form_layout = QVBoxLayout(form)
+        form_layout.setContentsMargins(0, 0, 0, 0)
+        form_layout.setSpacing(Spacing.SM)
+
+        for tier in TIER_ORDER:
+            row = QHBoxLayout()
+            row.setSpacing(Spacing.MD)
+
+            dot = QLabel("●")
+            dot.setFixedWidth(14)
+            dot.setStyleSheet(
+                f"color: {tier_colors[tier]}; font-size: 14px;"
+                f"background: transparent; border: none;"
+            )
+            row.addWidget(dot)
+
+            lbl = QLabel(TIER_DISPLAY[tier])
+            lbl.setFixedWidth(80)
+            lbl.setStyleSheet(
+                f"color: {Colors.TEXT_PRIMARY}; font-size: {Fonts.SIZE_SM};"
+                f"font-weight: {Fonts.WEIGHT_MEDIUM}; background: transparent; border: none;"
+            )
+            row.addWidget(lbl)
+
+            spin = QDoubleSpinBox()
+            spin.setRange(0.0, 100.0)
+            spin.setDecimals(1)
+            spin.setSingleStep(1.0)
+            spin.setSuffix("  %")
+            spin.setFixedWidth(110)
+            spin.setStyleSheet(f"""
+                QDoubleSpinBox {{
+                    background-color: {Colors.BG_SECONDARY};
+                    color: {Colors.TEXT_PRIMARY};
+                    border: 1px solid {Colors.BORDER_DEFAULT};
+                    border-radius: {BorderRadius.SM};
+                    padding: 4px 6px;
+                    font-size: {Fonts.SIZE_SM};
+                }}
+                QDoubleSpinBox:focus {{
+                    border-color: {Colors.BLUE_500};
+                }}
+            """)
+            row.addWidget(spin)
+            row.addStretch()
+
+            hint = QLabel("(min score for this tier)")
+            hint.setStyleSheet(
+                f"color: {Colors.TEXT_MUTED}; font-size: {Fonts.SIZE_XS};"
+                f"background: transparent; border: none;"
+            )
+            row.addWidget(hint)
+
+            self._spinboxes[tier] = spin
+            form_layout.addLayout(row)
+
+        root.addWidget(form)
+
+        sep2 = QFrame()
+        sep2.setFrameShape(QFrame.HLine)
+        sep2.setStyleSheet(f"color: {Colors.BORDER_MUTED};")
+        root.addWidget(sep2)
+
+        # Button row
+        btn_row = QHBoxLayout()
+        btn_row.setSpacing(Spacing.SM)
+
+        reset_btn = QPushButton("Reset to defaults")
+        reset_btn.setStyleSheet(Styles.button_secondary())
+        reset_btn.clicked.connect(self._on_reset)
+        btn_row.addWidget(reset_btn)
+        btn_row.addStretch()
+
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.setStyleSheet(Styles.button_secondary())
+        cancel_btn.clicked.connect(self.reject)
+        btn_row.addWidget(cancel_btn)
+
+        save_btn = QPushButton("Save")
+        save_btn.setStyleSheet(Styles.button_primary())
+        save_btn.setDefault(True)
+        save_btn.clicked.connect(self._on_save)
+        btn_row.addWidget(save_btn)
+
+        root.addLayout(btn_row)
+
+    # ------------------------------------------------------------------
+    # Data helpers
+    # ------------------------------------------------------------------
+
+    def _get_stored_thresholds(self) -> Dict[str, float]:
+        """Return the stored thresholds for the current metric, or defaults."""
+        all_thresholds = config.get(Settings.TRACKING_ERROR_THRESHOLDS, {})
+        if isinstance(all_thresholds, dict) and self._metric_name in all_thresholds:
+            stored = all_thresholds[self._metric_name]
+            # Merge with defaults to cover any missing tier keys
+            defaults = DEFAULT_THRESHOLDS.get(self._metric_name, {})
+            return {tier: stored.get(tier, defaults.get(tier, 60.0)) for tier in TIER_ORDER}
+        return dict(DEFAULT_THRESHOLDS.get(self._metric_name, {}))
+
+    def _load_current_thresholds(self):
+        thresholds = self._get_stored_thresholds()
+        for tier, spin in self._spinboxes.items():
+            spin.setValue(thresholds.get(tier, 60.0))
+
+    def _write_thresholds_to_config(self, thresholds: Dict[str, float]):
+        all_thresholds = config.get(Settings.TRACKING_ERROR_THRESHOLDS, {})
+        if not isinstance(all_thresholds, dict):
+            all_thresholds = {}
+        all_thresholds[self._metric_name] = thresholds
+        config.set(Settings.TRACKING_ERROR_THRESHOLDS, all_thresholds)
+
+    # ------------------------------------------------------------------
+    # Slots
+    # ------------------------------------------------------------------
+
+    def _on_save(self):
+        thresholds = {tier: self._spinboxes[tier].value() for tier in TIER_ORDER}
+        self._write_thresholds_to_config(thresholds)
+        self.accept()
+
+    def _on_reset(self):
+        defaults = DEFAULT_THRESHOLDS.get(self._metric_name, {})
+        for tier, spin in self._spinboxes.items():
+            spin.setValue(defaults.get(tier, 60.0))
+        # Write resets immediately so live repaint works if caller polls config
+        self._write_thresholds_to_config(dict(defaults))

--- a/hdsemg_pipe/widgets/wizard/FileQualitySelectionWizardWidget.py
+++ b/hdsemg_pipe/widgets/wizard/FileQualitySelectionWizardWidget.py
@@ -16,7 +16,8 @@ import pandas as pd
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QCheckBox, QComboBox, QFrame, QHBoxLayout, QLabel, QPushButton,
-    QScrollArea, QSizePolicy, QSplitter, QToolButton, QVBoxLayout, QWidget,
+    QScrollArea, QSizePolicy, QSplitter, QStyleFactory, QToolButton,
+    QVBoxLayout, QWidget,
 )
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
@@ -496,13 +497,20 @@ class FileQualitySelectionWizardWidget(WizardStepWidget):
         dev_hdr_layout.addWidget(QLabel("TRACKING DEVIATION", styleSheet=_ts))
 
         self._metric_combo = QComboBox()
+        # Force Fusion style so the popup list respects Qt stylesheets on macOS
+        # (native macOS rendering ignores QAbstractItemView stylesheet rules).
+        fusion = QStyleFactory.create("Fusion")
+        if fusion:
+            self._metric_combo.setStyle(fusion)
         self._metric_combo.addItems(METRIC_NAMES)
         self._metric_combo.setCurrentText(self._active_metric)
         self._metric_combo.setFixedHeight(18)
+        self._metric_combo.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self._metric_combo.view().setMinimumWidth(200)
         self._metric_combo.setStyleSheet(f"""
             QComboBox {{
-                background-color: {Colors.BG_SECONDARY};
-                color: {Colors.TEXT_SECONDARY};
+                background-color: {Colors.BG_PRIMARY};
+                color: {Colors.TEXT_PRIMARY};
                 border: 1px solid {Colors.BORDER_MUTED};
                 border-radius: {BorderRadius.SM};
                 font-size: {Fonts.SIZE_XS};
@@ -510,10 +518,28 @@ class FileQualitySelectionWizardWidget(WizardStepWidget):
                 padding: 1px 4px;
             }}
             QComboBox::drop-down {{ border: none; width: 14px; }}
-            QComboBox QAbstractItemView {{
-                background-color: {Colors.BG_SECONDARY};
+        """)
+        # Style the popup list view directly — macOS native style ignores
+        # QAbstractItemView rules nested inside the parent QComboBox stylesheet.
+        self._metric_combo.view().setStyleSheet(f"""
+            QAbstractItemView {{
+                background-color: {Colors.BG_PRIMARY};
                 color: {Colors.TEXT_PRIMARY};
                 selection-background-color: {Colors.BLUE_100};
+                selection-color: {Colors.TEXT_PRIMARY};
+                outline: none;
+                font-size: {Fonts.SIZE_SM};
+            }}
+            QAbstractItemView::item {{
+                color: {Colors.TEXT_PRIMARY};
+                background-color: {Colors.BG_PRIMARY};
+                padding: 4px 8px;
+                min-height: 22px;
+            }}
+            QAbstractItemView::item:selected,
+            QAbstractItemView::item:hover {{
+                background-color: {Colors.BLUE_100};
+                color: {Colors.TEXT_PRIMARY};
             }}
         """)
         self._metric_combo.currentTextChanged.connect(self._on_metric_changed)

--- a/hdsemg_pipe/widgets/wizard/FileQualitySelectionWizardWidget.py
+++ b/hdsemg_pipe/widgets/wizard/FileQualitySelectionWizardWidget.py
@@ -15,35 +15,56 @@ import numpy as np
 import pandas as pd
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
-    QCheckBox, QFrame, QHBoxLayout, QLabel, QPushButton,
-    QScrollArea, QSizePolicy, QSplitter, QVBoxLayout, QWidget,
+    QCheckBox, QComboBox, QFrame, QHBoxLayout, QLabel, QPushButton,
+    QScrollArea, QSizePolicy, QSplitter, QToolButton, QVBoxLayout, QWidget,
 )
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 
 from hdsemg_pipe._log.log_config import logger
+from hdsemg_pipe.actions.tracking_error_metrics import (
+    DEFAULT_THRESHOLDS, METRIC_NAMES, METRIC_NRMSE,
+    TIER_ORDER, compute_metric,
+)
 from hdsemg_pipe.config.config_enums import Settings
 from hdsemg_pipe.config.config_manager import config
 from hdsemg_pipe.state.global_state import global_state
 from hdsemg_pipe.ui_elements.theme import BorderRadius, Colors, Fonts, Spacing, Styles
 from hdsemg_pipe.widgets.WizardStepWidget import WizardStepWidget
+from hdsemg_pipe.widgets.dialogs.TrackingErrorThresholdsDialog import (
+    TrackingErrorThresholdsDialog,
+)
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _score_to_label_color(score: Optional[float]) -> Tuple[str, str]:
-    """Map NRMSE score (0–100 %) to (label, hex_color)."""
+def _score_to_label_color(
+    score: Optional[float],
+    thresholds: Optional[Dict[str, float]] = None,
+) -> Tuple[str, str]:
+    """Map a 0–100 quality score to (label, hex_color).
+
+    Parameters
+    ----------
+    score:
+        Quality score in [0, 100] or None.
+    thresholds:
+        Optional dict mapping tier name → minimum score boundary.  When omitted
+        the NRMSE defaults (90/80/70/60) are used for backwards compatibility.
+    """
     if score is None:
         return "N/A", Colors.GRAY_400
-    if score >= 90:
+    if thresholds is None:
+        thresholds = DEFAULT_THRESHOLDS[METRIC_NRMSE]
+    if score >= thresholds.get("excellent", 90):
         return "Excellent", Colors.GREEN_500
-    if score >= 80:
+    if score >= thresholds.get("good", 80):
         return "Good", Colors.BLUE_500
-    if score >= 70:
+    if score >= thresholds.get("ok", 70):
         return "OK", Colors.YELLOW_500
-    if score >= 60:
+    if score >= thresholds.get("troubled", 60):
         return "Troubled", Colors.ORANGE_500
     return "Bad", Colors.RED_500
 
@@ -62,20 +83,6 @@ def _rms_to_label_color(rms: Optional[float]) -> Tuple[str, str]:
         return "Troubled", Colors.ORANGE_500
     return "Bad", Colors.RED_500
 
-
-def _compute_nrmse_score(required: np.ndarray, performed: np.ndarray) -> Optional[float]:
-    """Compute 0–100 % tracking quality score (100 = perfect match).
-
-    Uses Normalized RMSE: score = max(0, (1 - RMSE / range(required)) * 100).
-    """
-    min_len = min(len(required), len(performed))
-    req = required[:min_len].astype(float)
-    perf = performed[:min_len].astype(float)
-    req_range = req.max() - req.min()
-    if req_range < 1e-10:
-        return None
-    rmse = np.sqrt(np.mean((req - perf) ** 2))
-    return max(0.0, (1.0 - rmse / req_range) * 100.0)
 
 
 # ---------------------------------------------------------------------------
@@ -283,6 +290,8 @@ class FileQualitySelectionWizardWidget(WizardStepWidget):
         self._last_grouped_mode: Optional[bool] = None
         self._group_file_map: Dict[str, List[str]] = {}   # group_key → [file_paths]
         self._group_headers: Dict[str, _GroupHeader] = {}  # group_key → header widget
+        # Tracking-error metric (persisted in config)
+        self._active_metric: str = config.get(Settings.TRACKING_ERROR_METRIC, METRIC_NRMSE)
 
         super().__init__(
             step_index=5,
@@ -476,7 +485,60 @@ class FileQualitySelectionWizardWidget(WizardStepWidget):
         dev_cv = QVBoxLayout(dev_col)
         dev_cv.setContentsMargins(0, 0, 0, 0)
         dev_cv.setSpacing(2)
-        dev_cv.addWidget(QLabel("TRACKING DEVIATION (NRMSE)", styleSheet=_ts))
+
+        # Deviation header row: label + metric combo + gear button
+        dev_hdr_row = QWidget()
+        dev_hdr_row.setStyleSheet("background:transparent;")
+        dev_hdr_layout = QHBoxLayout(dev_hdr_row)
+        dev_hdr_layout.setContentsMargins(0, 0, 0, 0)
+        dev_hdr_layout.setSpacing(Spacing.XS)
+
+        dev_hdr_layout.addWidget(QLabel("TRACKING DEVIATION", styleSheet=_ts))
+
+        self._metric_combo = QComboBox()
+        self._metric_combo.addItems(METRIC_NAMES)
+        self._metric_combo.setCurrentText(self._active_metric)
+        self._metric_combo.setFixedHeight(18)
+        self._metric_combo.setStyleSheet(f"""
+            QComboBox {{
+                background-color: {Colors.BG_SECONDARY};
+                color: {Colors.TEXT_SECONDARY};
+                border: 1px solid {Colors.BORDER_MUTED};
+                border-radius: {BorderRadius.SM};
+                font-size: {Fonts.SIZE_XS};
+                font-weight: {Fonts.WEIGHT_MEDIUM};
+                padding: 1px 4px;
+            }}
+            QComboBox::drop-down {{ border: none; width: 14px; }}
+            QComboBox QAbstractItemView {{
+                background-color: {Colors.BG_SECONDARY};
+                color: {Colors.TEXT_PRIMARY};
+                selection-background-color: {Colors.BLUE_100};
+            }}
+        """)
+        self._metric_combo.currentTextChanged.connect(self._on_metric_changed)
+        dev_hdr_layout.addWidget(self._metric_combo)
+
+        self._thresholds_btn = QToolButton()
+        self._thresholds_btn.setText("⚙")
+        self._thresholds_btn.setFixedSize(18, 18)
+        self._thresholds_btn.setToolTip("Configure quality thresholds…")
+        self._thresholds_btn.setStyleSheet(f"""
+            QToolButton {{
+                background: transparent;
+                color: {Colors.TEXT_MUTED};
+                border: none;
+                font-size: 11px;
+                padding: 0px;
+            }}
+            QToolButton:hover {{ color: {Colors.TEXT_PRIMARY}; }}
+        """)
+        self._thresholds_btn.clicked.connect(self._on_open_thresholds_dialog)
+        dev_hdr_layout.addWidget(self._thresholds_btn)
+        dev_hdr_layout.addStretch()
+
+        dev_cv.addWidget(dev_hdr_row)
+
         self._dev_value_lbl = QLabel("—")
         self._dev_value_lbl.setStyleSheet(_vs)
         self._dev_quality_lbl = QLabel("")
@@ -840,8 +902,10 @@ class FileQualitySelectionWizardWidget(WizardStepWidget):
         # Deviation score
         score: Optional[float] = None
         if required is not None and performed is not None:
-            score = _compute_nrmse_score(required, performed)
+            score = compute_metric(self._active_metric, required, performed)
         self._score_cache[file_path] = score
+
+        thresholds = self._get_active_thresholds()
 
         # RMS
         rms_result = self._get_rms_for_file(file_path)
@@ -850,7 +914,7 @@ class FileQualitySelectionWizardWidget(WizardStepWidget):
 
         # Update status dot colour in the list (prefer deviation score if available)
         if score is not None:
-            dot_color = _score_to_label_color(score)[1]
+            dot_color = _score_to_label_color(score, thresholds)[1]
         elif rms_mean is not None and not np.isnan(rms_mean):
             dot_color = _rms_to_label_color(rms_mean)[1]
         else:
@@ -860,7 +924,7 @@ class FileQualitySelectionWizardWidget(WizardStepWidget):
 
         # Deviation stat
         if score is not None:
-            slabel, scolor = _score_to_label_color(score)
+            slabel, scolor = _score_to_label_color(score, thresholds)
             self._update_stat(self._dev_value_lbl, self._dev_quality_lbl,
                               f"{score:.1f} %", slabel, scolor)
         else:
@@ -876,6 +940,37 @@ class FileQualitySelectionWizardWidget(WizardStepWidget):
                               value_text, rlabel, rcolor)
         else:
             self._reset_stat(self._rms_value_lbl, self._rms_quality_lbl)
+
+    # ------------------------------------------------------------------
+    # Metric / threshold helpers and slots
+    # ------------------------------------------------------------------
+
+    def _get_active_thresholds(self) -> Dict[str, float]:
+        """Return the tier thresholds for the currently active metric."""
+        all_thresholds = config.get(Settings.TRACKING_ERROR_THRESHOLDS, {})
+        if isinstance(all_thresholds, dict) and self._active_metric in all_thresholds:
+            stored = all_thresholds[self._active_metric]
+            defaults = DEFAULT_THRESHOLDS.get(self._active_metric, {})
+            return {tier: stored.get(tier, defaults.get(tier, 60.0)) for tier in TIER_ORDER}
+        return dict(DEFAULT_THRESHOLDS.get(self._active_metric, {}))
+
+    def _on_metric_changed(self, metric_name: str):
+        """Switch active metric, persist to config, invalidate score cache, repaint."""
+        self._active_metric = metric_name
+        config.set(Settings.TRACKING_ERROR_METRIC, metric_name)
+        # Scores depend on the metric — invalidate so they are recomputed on next view
+        self._score_cache.clear()
+        # Repaint all quality dots that are already loaded by re-visiting current file
+        if self._current_file:
+            self._on_file_selected(self._current_file)
+
+    def _on_open_thresholds_dialog(self):
+        """Open the thresholds dialog for the active metric and repaint on close."""
+        dlg = TrackingErrorThresholdsDialog(self._active_metric, parent=self)
+        dlg.exec_()
+        # Regardless of accept/reject, thresholds may have changed (reset on "Reset")
+        if self._current_file:
+            self._on_file_selected(self._current_file)
 
     # ------------------------------------------------------------------
     # Stat label helpers


### PR DESCRIPTION
# Summary

Implements [#130](https://github.com/johanneskasser/hdsemg-pipe/issues/130).

- **New module** `hdsemg_pipe/actions/tracking_error_metrics.py` — NRMSE, RMSE, MSE, MAE, and Pearson r metrics, all normalised to a 0–100 quality score; shared `DEFAULT_THRESHOLDS` dict and `compute_metric()` dispatcher
- **Config enums** — added `TRACKING_ERROR_METRIC` and `TRACKING_ERROR_THRESHOLDS` to `Settings`; persisted via the existing `ConfigManager` singleton
- **New dialog** `TrackingErrorThresholdsDialog` — shows four `QDoubleSpinBox` rows (Excellent / Good / OK / Troubled) for the selected metric, "Reset to defaults", writes to config on Save so the parent repaints live
- **Widget update** `FileQualitySelectionWizardWidget` — replaces the static `TRACKING DEVIATION (NRMSE)` label with a `QComboBox` + ⚙ `QToolButton`; switching metric clears the score cache and repaints the current file immediately; selected metric and thresholds survive app restarts

## Test plan

- [x] Step 5 shows metric dropdown and gear icon in the deviation header
- [x] Switching metric → file quality colours/labels update immediately
- [x] Click gear → dialog shows current thresholds for selected metric
- [x] Change thresholds → Save → colours repaint live
- [x] Restart app → selected metric and thresholds restored from `config/config.json`
- [x] "Reset to defaults" button restores per-metric defaults
- [x] All existing NRMSE behaviour unchanged when NRMSE is selected with default thresholds
